### PR TITLE
B2BQUOTES-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- UI to change of expiration date by sales role
+- Improvement of quote details UI
+
 ## [0.1.1] - 2022-03-02
+
 ### Fixed
+
 - Clicking on request quote button creates the same quote multiple times
 - Fixed the loading button controllers
 - Clear cart ui after create quote has been created

--- a/messages/context.json
+++ b/messages/context.json
@@ -68,5 +68,6 @@
   "store/b2b-quotes.quote-details.original-subtotal.title": "Original Subtotal",
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
-  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal"
+  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -68,5 +68,6 @@
   "store/b2b-quotes.quote-details.original-subtotal.title": "Original Subtotal",
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
-  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal"
+  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -68,5 +68,6 @@
   "store/b2b-quotes.quote-details.original-subtotal.title": "Original Subtotal",
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
-  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal"
+  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -68,5 +68,6 @@
   "store/b2b-quotes.quote-details.original-subtotal.title": "Original Subtotal",
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
-  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal"
+  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -68,5 +68,6 @@
   "store/b2b-quotes.quote-details.original-subtotal.title": "Original Subtotal",
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
-  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal"
+  "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
 }

--- a/react/graphql/updateQuote.graphql
+++ b/react/graphql/updateQuote.graphql
@@ -4,6 +4,7 @@ mutation UpdateQuote(
   $subtotal: Float
   $note: String
   $decline: Boolean
+  $expirationDate: String
 ) {
   updateQuote(
     input: {
@@ -12,6 +13,7 @@ mutation UpdateQuote(
       subtotal: $subtotal
       note: $note
       decline: $decline
+      expirationDate: $expirationDate
     }
   ) @context(provider: "vtex.b2b-quotes-graphql")
 }

--- a/react/typings/vtex.styleguide.d.ts
+++ b/react/typings/vtex.styleguide.d.ts
@@ -2,6 +2,7 @@ declare module 'vtex.styleguide' {
   export const PageHeader
   export const Alert
   export const Modal
+  export const DatePicker
   export const Box
   export const Card
   export const Checkbox


### PR DESCRIPTION
Added UI component to change of expiration date by sales role

### New feature

- Add the ability for sales roles to override the default expiration date for a quote

BACKEND PR: [https://github.com/vtex-apps/b2b-quotes-graphql/pull/6](https://github.com/vtex-apps/b2b-quotes-graphql/pull/6)

#### How to test it?

artur.magalhaes@vtex.com.br / Vtex1234
[https://quotes1--b2bstoreqa.myvtex.com/b2b-quotes/](https://quotes1--b2bstoreqa.myvtex.com/b2b-quotes/)


#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/5812946/156434793-1a145320-5e1a-44a8-91f4-64c8a794d030.png)

