### PR TITLE
[B2BQUOTES-17] Add quotes to My Account, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Quotes and Saved Carts` link to My Account menu
+
+### Fixed
+
+- When creating new quote, calculate subtotal from list of items rather than using totalizers from orderForm (if items currently have no availability, they will not be included in totalizer amount)
+- If a promotion causes two instances of the same SKU to have different selling prices, add them to the quote as separate lines
+- Do not allow free items to be added to quote
+- Use `network-only` fetch policy when fetching quotes to ensure freshest data
+- Remove unnecessary refetches
+
 ## [0.2.0] - 2022-03-10
 
 ### Added
@@ -27,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Improvement of Quote Details,
-- Calculate the discount against original price (listPrice item) 
+- Calculate the discount against original price (listPrice item)
 - If user input some value above from max discount, it's blocked to save, and an alert is shown.
 
 ## [0.0.3] - 2022-01-06

--- a/manifest.json
+++ b/manifest.json
@@ -24,11 +24,11 @@
     "vtex.order-auth-graphql": "0.x",
     "vtex.store-graphql": "2.x",
     "vtex.css-handles": "0.x",
-    "vtex.format-currency": "0.x"
+    "vtex.format-currency": "0.x",
+    "vtex.my-account": "1.x",
+    "vtex.my-account-commons": "1.x"
   },
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "policies": [],
   "billingOptions": {
     "termsURL": "https://compliance.vtex.com/gdpr/policies/vtex-privacy-policy",
@@ -37,9 +37,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "settingsSchema": {
     "title": "B2B Quotes & Carts",
@@ -60,24 +58,15 @@
             "minimum": 1
           }
         },
-        "required": [
-          "cartLifeSpan"
-        ]
+        "required": ["cartLifeSpan"]
       }
     },
-    "required": [
-      "adminSetup"
-    ]
+    "required": ["adminSetup"]
   },
   "settingsUiSchema": {
-    "ui:order": [
-      "adminSetup",
-      "hasSchema"
-    ],
+    "ui:order": ["adminSetup", "hasSchema"],
     "adminSetup": {
-      "ui:order": [
-        "cartLifeSpan"
-      ]
+      "ui:order": ["cartLifeSpan"]
     },
     "hasSchema": {
       "ui:widget": "hidden"

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,4 +1,5 @@
 {
+  "store/b2b-quotes.myAccountLink": "Quotes and Saved Carts",
   "store/b2b-quotes.create.title": "Create Quote",
   "store/b2b-quotes.create.nameLabel": "Name",
   "store/b2b-quotes.create.descriptionLabel": "Notes",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,5 @@
 {
+  "store/b2b-quotes.myAccountLink": "Quotes and Saved Carts",
   "store/b2b-quotes.create.title": "Create Quote",
   "store/b2b-quotes.create.nameLabel": "Name",
   "store/b2b-quotes.create.descriptionLabel": "Notes",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,4 +1,5 @@
 {
+  "store/b2b-quotes.myAccountLink": "Quotes and Saved Carts",
   "store/b2b-quotes.create.title": "Guardar Cotización",
   "store/b2b-quotes.create.nameLabel": "Nombre",
   "store/b2b-quotes.create.descriptionLabel": "Descripción",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,4 +1,5 @@
 {
+  "store/b2b-quotes.myAccountLink": "Quotes and Saved Carts",
   "store/b2b-quotes.create.title": "Crie uma cotação",
   "store/b2b-quotes.create.nameLabel": "Nome",
   "store/b2b-quotes.create.descriptionLabel": "Descrição",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,4 +1,5 @@
 {
+  "store/b2b-quotes.myAccountLink": "Quotes and Saved Carts",
   "store/b2b-quotes.create.title": "Salvați oferta",
   "store/b2b-quotes.create.nameLabel": "Nume",
   "store/b2b-quotes.create.descriptionLabel": "Descriere",

--- a/react/B2BQuotesLink.tsx
+++ b/react/B2BQuotesLink.tsx
@@ -1,0 +1,26 @@
+import type { FunctionComponent, ReactElement } from 'react'
+import { defineMessages, useIntl } from 'react-intl'
+
+const messages = defineMessages({
+  myQuotes: {
+    id: 'store/b2b-quotes.myAccountLink',
+  },
+})
+
+const B2BQuotesLink: FunctionComponent<Props> = ({ render }) => {
+  const { formatMessage } = useIntl()
+
+  return render([
+    {
+      name: formatMessage(messages.myQuotes),
+      path: `/b2b-quotes`,
+    },
+  ])
+}
+
+type Props = {
+  render: (links: Array<{ name: string; path: string }>) => ReactElement
+  intl: any
+}
+
+export default B2BQuotesLink

--- a/react/B2BQuotesListAccount.tsx
+++ b/react/B2BQuotesListAccount.tsx
@@ -1,0 +1,23 @@
+import type { FC } from 'react'
+import React, { Fragment } from 'react'
+import { Route } from 'vtex.my-account-commons/Router'
+import { useRuntime } from 'vtex.render-runtime'
+import { Spinner } from 'vtex.styleguide'
+
+const B2BQuotesRedirect: FC = () => {
+  const { navigate } = useRuntime()
+
+  navigate({
+    page: 'store.b2b-quotes',
+  })
+
+  return <Spinner />
+}
+
+const B2BQuotesListAccount = () => (
+  <Fragment>
+    <Route exact path="/b2b-quotes" component={B2BQuotesRedirect} />
+  </Fragment>
+)
+
+export default B2BQuotesListAccount

--- a/react/components/CreateQuote.tsx
+++ b/react/components/CreateQuote.tsx
@@ -49,7 +49,7 @@ const useSessionResponse = () => {
 }
 
 let isAuthenticated =
-  JSON.parse(String(localStore.getItem('orderquote_isAuthenticated'))) ?? false
+  JSON.parse(String(localStore.getItem('b2bquotes_isAuthenticated'))) ?? false
 
 const storePrefix = 'store/b2b-quotes.'
 
@@ -132,6 +132,7 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
   })
 
   const [itemState, setItemState] = useState([] as QuoteItem[])
+  const [subtotalState, setSubtotalState] = useState(0)
   const [sentToSalesRep, setSentToSalesRep] = useState(false)
   const { formatMessage } = useIntl()
   const { navigate } = useRuntime()
@@ -157,20 +158,27 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
     if (!data?.orderForm?.items?.length) return
 
     const itemsCopy = [] as QuoteItem[]
+    let subtotal = 0
 
     data.orderForm.items.forEach((item: QuoteItem) => {
       const existingItem = itemsCopy.find(
-        (existing: QuoteItem) => existing.id === item.id
+        (existing: QuoteItem) =>
+          existing.id === item.id && existing.sellingPrice === item.sellingPrice
       )
 
       if (existingItem) {
         existingItem.quantity += item.quantity
-      } else {
+      } else if (item.sellingPrice !== 0) {
         itemsCopy.push(item)
       }
     })
 
+    itemsCopy.forEach((item: QuoteItem) => {
+      subtotal += item.sellingPrice * item.quantity * 100
+    })
+
     setItemState(itemsCopy)
+    setSubtotalState(subtotal)
   }, [data])
 
   const [SaveCartMutation] = useMutation(saveCartMutation)
@@ -181,7 +189,7 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
       sessionResponse?.namespaces?.profile?.isAuthenticated?.value === 'true'
 
     localStore.setItem(
-      'orderquote_isAuthenticated',
+      'b2bquotes_isAuthenticated',
       JSON.stringify(isAuthenticated)
     )
   }
@@ -198,7 +206,6 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
     properties: {
       imageUrl: {
         title: formatMessage(messages.image),
-        // eslint-disable-next-line react/display-name
         cellRenderer: ({ rowData: { imageUrl, skuName } }: any) =>
           imageUrl && (
             <div className="dib v-mid relative">
@@ -220,7 +227,6 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
       },
       name: {
         title: formatMessage(messages.name),
-        // eslint-disable-next-line react/display-name
         cellRenderer: ({ rowData }: any) => {
           return (
             <div className={handles.itemNameContainer}>
@@ -241,7 +247,6 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
       sellingPrice: {
         title: formatMessage(messages.price),
         headerRight: true,
-        // eslint-disable-next-line react/display-name
         cellRenderer: ({ cellData }: any) => {
           return (
             <span className="tr w-100">
@@ -258,7 +263,6 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
       total: {
         title: formatMessage(messages.total),
         headerRight: true,
-        // eslint-disable-next-line react/display-name
         cellRenderer: ({ rowData }: any) => {
           return (
             <span className="tr w-100">
@@ -273,27 +277,21 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
     },
   }
 
-  const { totalizers } = data?.orderForm ?? {}
+  // const { totalizers } = data?.orderForm ?? {}
 
-  const subtotal = (
-    totalizers?.find((x: { id: string }) => x.id === 'Items') || {
-      value: 0,
-    }
-  ).value
-
-  // TODO: Capture order-level discounts
-  //
-  //   const discounts = (
-  //     totalizers?.find((x: { id: string }) => x.id === 'Discounts') || {
-  //       value: 0,
-  //     }
-  //   ).value
+  // const subtotal = (
+  //   totalizers?.find((x: { id: string }) => x.id === 'Items') || {
+  //     value: 0,
+  //   }
+  // ).value
 
   const summary = [
     {
       label: formatMessage(messages.subtotal),
       value: (
-        <FormattedCurrency value={subtotal === 0 ? subtotal : subtotal / 100} />
+        <FormattedCurrency
+          value={subtotalState === 0 ? subtotalState : subtotalState / 100}
+        />
       ),
       isLoading: false,
     },
@@ -335,7 +333,7 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
             sellingPrice: parseInt(String(item.sellingPrice * 100), 10),
           }
         }),
-        subtotal: parseInt(String(subtotal), 10),
+        subtotal: parseInt(String(subtotalState), 10),
         note: _state.note,
         sendToSalesRep,
       }
@@ -348,22 +346,23 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
             toastMessage(messages.createSuccess)
             handleClearCart(orderForm.orderFormId).then(() => {
               setItemState([])
-              refetch().then((resp: any) => {
-                if (resp?.data?.orderForm) {
-                  setOrderForm(resp?.data?.orderForm)
-                }
+              setSubtotalState(0)
+              setTimeout(() => {
+                refetch().then((resp: any) => {
+                  if (resp?.data?.orderForm) {
+                    setOrderForm(resp?.data?.orderForm)
+                  }
 
-                setTimeout(() => {
                   activeLoading(false)
                   navigate({
                     page: 'store.b2b-quotes',
                     fallbackToWindowLocation: true,
                     fetchPage: true,
                   })
-                }, 500)
 
-                return resp
-              })
+                  return resp
+                })
+              }, 500)
             })
           } else {
             toastMessage(messages.createError)
@@ -390,10 +389,6 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
   }
 
   const { permissions = [] } = permissionsData?.checkUserPermission ?? {}
-
-  useEffect(() => {
-    refetch()
-  }, [refetch])
 
   return (
     <Layout fullWidth>

--- a/react/components/CreateQuote.tsx
+++ b/react/components/CreateQuote.tsx
@@ -151,6 +151,7 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
   )
 
   const { data, refetch } = useQuery(getOrderForm, {
+    fetchPolicy: 'network-only',
     ssr: false,
   })
 

--- a/react/components/CreateQuote.tsx
+++ b/react/components/CreateQuote.tsx
@@ -277,14 +277,6 @@ const QuoteCreate: StorefrontFunctionComponent = () => {
     },
   }
 
-  // const { totalizers } = data?.orderForm ?? {}
-
-  // const subtotal = (
-  //   totalizers?.find((x: { id: string }) => x.id === 'Items') || {
-  //     value: 0,
-  //   }
-  // ).value
-
   const summary = [
     {
       label: formatMessage(messages.subtotal),

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -124,7 +124,7 @@ const messages = defineMessages({
     id: `${storePrefix}quote-details.original-price.title`,
   },
   expirationDateChange: {
-    id: `${storePrefix}quote-details.expiration-data-change.title`,
+    id: `${storePrefix}quote-details.expiration-date-change.title`,
   },
 })
 

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -162,8 +162,6 @@ const QuoteDetails: FunctionComponent = () => {
     showToast({ message: translatedMessage, duration: 5000, action })
   }
 
-  // const { orderForm } = useOrderForm()
-
   const formatPrice = (value: number) =>
     formatCurrency({
       intl,
@@ -607,7 +605,6 @@ const QuoteDetails: FunctionComponent = () => {
                         },
                         name: {
                           title: formatMessage(messages.name),
-                          // eslint-disable-next-line react/display-name
                           cellRenderer: ({ rowData }: any) => {
                             return (
                               <div>
@@ -703,7 +700,6 @@ const QuoteDetails: FunctionComponent = () => {
                         total: {
                           title: formatMessage(messages.total),
                           headerRight: true,
-                          // eslint-disable-next-line react/display-name
                           cellRenderer: ({ rowData }: any) => {
                             return (
                               <span className="tr w-100">

--- a/react/components/QuotesTableContainer.tsx
+++ b/react/components/QuotesTableContainer.tsx
@@ -2,6 +2,7 @@ import type { FunctionComponent, ChangeEvent } from 'react'
 import React, { useState, useEffect } from 'react'
 import { useQuery } from 'react-apollo'
 import { FormattedMessage } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
 import { Layout, PageHeader, PageBlock, Spinner } from 'vtex.styleguide'
 
 import QuotesTable from './QuotesTable'
@@ -35,6 +36,7 @@ let isAuthenticated =
   JSON.parse(String(localStore.getItem('orderquote_isAuthenticated'))) ?? false
 
 const QuotesTableContainer: FunctionComponent = () => {
+  const { navigate, rootPath } = useRuntime()
   const [paginationState, setPaginationState] = useState({
     page: 1,
     pageSize: 25,
@@ -278,6 +280,12 @@ const QuotesTableContainer: FunctionComponent = () => {
     return (
       <PageHeader
         title={<FormattedMessage id="store/b2b-quotes.quotes-table.title" />}
+        linkLabel={<FormattedMessage id="store/b2b-quotes.back" />}
+        onLinkClick={() =>
+          navigate({
+            to: `${rootPath ?? ''}/account`,
+          })
+        }
       />
     )
   }

--- a/react/components/QuotesTableContainer.tsx
+++ b/react/components/QuotesTableContainer.tsx
@@ -76,13 +76,10 @@ const QuotesTableContainer: FunctionComponent = () => {
     }
   )
 
-  const { data, loading, refetch } = useQuery(GET_QUOTES, { ssr: false })
-
-  useEffect(() => {
-    refetch()
-  }, [refetch])
-
-  if (!data || (isAuthenticated && !permissionsData)) return null
+  const { data, loading, refetch } = useQuery(GET_QUOTES, {
+    fetchPolicy: 'network-only',
+    ssr: false,
+  })
 
   const handlePrevClick = () => {
     if (paginationState.page === 1) return
@@ -316,11 +313,11 @@ const QuotesTableContainer: FunctionComponent = () => {
       <div className="mw9 center">
         <Layout fullWidth pageHeader={<QuotesTablePageHeader />}>
           <QuotesTable
-            quotes={data.getQuotes?.data ?? []}
+            quotes={data?.getQuotes?.data ?? []}
             permissions={permissionsData.checkUserPermission.permissions}
             page={paginationState.page}
             pageSize={paginationState.pageSize}
-            total={data.getQuotes?.pagination?.total ?? 0}
+            total={data?.getQuotes?.pagination?.total ?? 0}
             loading={loading}
             handlePrevClick={handlePrevClick}
             handleNextClick={handleNextClick}

--- a/react/package.json
+++ b/react/package.json
@@ -18,15 +18,20 @@
     "@types/react-intl": "^3.0.0",
     "@vtex/test-tools": "^3.1.0",
     "@vtex/tsconfig": "^0.5.6",
-    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.46.0/public/@types/vtex.checkout-resources",
-    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.64.3/public/@types/vtex.checkout-graphql",
+    "vtex.b2b-organizations-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.10.0/public/@types/vtex.b2b-organizations-graphql",
+    "vtex.b2b-quotes-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@1.3.0/public/@types/vtex.b2b-quotes-graphql",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.65.1/public/@types/vtex.checkout-graphql",
+    "vtex.checkout-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.48.0/public/@types/vtex.checkout-resources",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
+    "vtex.my-account": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account",
+    "vtex.my-account-commons": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons",
     "vtex.order-auth-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-auth-graphql@0.2.1/public/_types/react",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.11.1/public/@types/vtex.order-manager",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.130.0/public/@types/vtex.render-runtime",
-    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.0/public/@types/vtex.store",
-    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.143.0/public/@types/vtex.store-graphql",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
+    "vtex.store": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.123.0/public/@types/vtex.store",
+    "vtex.store-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.3/public/@types/vtex.store-graphql",
+    "vtex.storefront-permissions": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.14.0/public/@types/vtex.storefront-permissions",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide"
   }
 }

--- a/react/typings/vtex.my-account-commons/Router.d.ts
+++ b/react/typings/vtex.my-account-commons/Router.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.my-account-commons/Router'

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5154,13 +5154,21 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.64.3/public/@types/vtex.checkout-graphql":
-  version "0.64.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.64.3/public/@types/vtex.checkout-graphql#1c01e3d68b4ee2458aa02bb91875a266d1687117"
+"vtex.b2b-organizations-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.10.0/public/@types/vtex.b2b-organizations-graphql":
+  version "0.10.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-organizations-graphql@0.10.0/public/@types/vtex.b2b-organizations-graphql#8f7ff441dcd4b07b7f4183b91945ec39c8544f43"
 
-"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.46.0/public/@types/vtex.checkout-resources":
-  version "0.46.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.46.0/public/@types/vtex.checkout-resources#a6c7a59fd9a92d44d486425bc311cb93ad5f0653"
+"vtex.b2b-quotes-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@1.3.0/public/@types/vtex.b2b-quotes-graphql":
+  version "1.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.b2b-quotes-graphql@1.3.0/public/@types/vtex.b2b-quotes-graphql#ebbfb0d8d93cebdd22416a53c0cb177df173ab24"
+
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.65.1/public/@types/vtex.checkout-graphql":
+  version "0.65.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.65.1/public/@types/vtex.checkout-graphql#04a998a449f1f5c293b5117d147bcb365d2b321b"
+
+"vtex.checkout-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.48.0/public/@types/vtex.checkout-resources":
+  version "0.48.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-resources@0.48.0/public/@types/vtex.checkout-resources#24e35deb51ead4662ae2214f877f018eaf40f846"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"
@@ -5170,6 +5178,14 @@ verror@1.10.0:
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency#1cb7360452552301237c16d32037bbac61798f20"
 
+"vtex.my-account-commons@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons":
+  version "1.6.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account-commons@1.6.0/public/@types/vtex.my-account-commons#3715228fb82e81e955e6a90d11e7975e72b37b2e"
+
+"vtex.my-account@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account":
+  version "1.25.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.my-account@1.25.0/public/@types/vtex.my-account#3bc46389c0aa28f4e3e2e008fe3690f5901b1f2a"
+
 "vtex.order-auth-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-auth-graphql@0.2.1/public/_types/react":
   version "0.0.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-auth-graphql@0.2.1/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
@@ -5178,21 +5194,25 @@ verror@1.10.0:
   version "0.11.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.11.1/public/@types/vtex.order-manager#cc658148c5e054900c0d692a26d1ac7c872d9262"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.130.0/public/@types/vtex.render-runtime":
-  version "8.130.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.130.0/public/@types/vtex.render-runtime#6958e1017c423c0906eae3500bad70d3fb353a98"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime":
+  version "8.132.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
 
-"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.143.0/public/@types/vtex.store-graphql":
-  version "2.143.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.143.0/public/@types/vtex.store-graphql#cf68a117e052ed36b03a683ee0063feaf37f17cd"
+"vtex.store-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.3/public/@types/vtex.store-graphql":
+  version "2.149.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-graphql@2.149.3/public/@types/vtex.store-graphql#f221e93ea4b4fb0867d2256956fd5080b3d24ff5"
 
-"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.0/public/@types/vtex.store":
-  version "2.120.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.120.0/public/@types/vtex.store#62930c752742172a6b3e545726feffbade76f3bd"
+"vtex.store@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.123.0/public/@types/vtex.store":
+  version "2.123.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store@2.123.0/public/@types/vtex.store#bde5670d4479f8a25b21b907ea04ed923a4ae676"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide":
-  version "9.145.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.145.0/public/@types/vtex.styleguide#41dfb32af8756eb5528dbd452e47003a8f67fe8c"
+"vtex.storefront-permissions@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.14.0/public/@types/vtex.storefront-permissions":
+  version "1.14.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.storefront-permissions@1.14.0/public/@types/vtex.storefront-permissions#c8ba095f20d0d3ed9ec1be2c485b782640ef186c"
+
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide":
+  version "9.146.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.146.1/public/@types/vtex.styleguide#66db40ca1b78ad77ce4beedabecee320e1ef2ead"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -16,5 +16,11 @@
   },
   "quote-details": {
     "component": "QuoteDetails"
+  },
+  "my-account-link.b2b-quotes": {
+    "component": "B2BQuotesLink"
+  },
+  "my-account-page.b2b-quotes": {
+    "component": "B2BQuotesListAccount"
   }
 }

--- a/store/plugins.json
+++ b/store/plugins.json
@@ -1,0 +1,4 @@
+{
+  "my-account-pages > my-account-page": "my-account-page.b2b-quotes",
+  "my-account-menu > my-account-link": "my-account-link.b2b-quotes"
+}


### PR DESCRIPTION
#### What problem is this solving?

Mostly this PR adds a "Quotes and Saved Carts" link to the My Account menu, which redirects the user to the `/b2b-quotes` URL. Unlike other My Account pages, the Quotes UI is not displayed inside the My Account context (i.e. no My Account sidebar is shown). This is deliberate because moving the UI inside the context would represent a breaking change (the old URLs would no longer work). However this is something we can consider for future implementation, perhaps in the next major release.

I also took the opportunity to fix a few minor issues in the code:  
- I removed a few unnecessary useEffect refetch statements
- When creating a quote, I added logic to calculate our own subtotal instead of using the items totalizer from the orderForm. I did this because the orderForm totalizer will leave out items if they currently have no availability or cannot be shipped to your address, but this is not relevant for the purposes of a quote
- I prevented free items (i.e. from a promotion) from being added to a quote
- If there are multiple instances of the same SKU in the cart with different selling prices (i.e. from a promotion), they will be represented as separate line items when creating a quote

#### How to test it?

Linked here: https://b2bsuite--sandboxusdev.myvtex.com
Log in as an organization user and go to My Account, then click on `Quotes and Saved Carts`