### PR TITLE
[B2BCHCKOUT] - Mini cart also needs checkout locking for quotes orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-<<<<<<< HEAD
 Added a modal component that verifies if the quoteId is on the orderForm and locks by opening the modal component if the user tries to browse other pages instead of the checkout page.
-=======
-Added a modal component that verifies if the quoteId is on the orderForm and lock by opening the modal component if the user tries to browse other pages instead of checkout page
->>>>>>> modal-block-quote
-
 
 ## [0.4.0] - 2022-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+Added a modal component that verifies if the quoteId is on the orderForm and locks by opening the modal component if the user tries to browse other pages instead of the checkout page.
+
+
 ## [0.4.0] - 2022-03-22
 
 ### Changed

--- a/messages/context.json
+++ b/messages/context.json
@@ -71,5 +71,9 @@
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
   "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
-  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change",
+  "store/b2b-quotes.quote-locking.title": "Quote in Use",
+  "store/b2b-quotes.quote-locking.message": " Your cart currently contains items from a quote and therefore cannot be modified. You may either return to checkout or clear your cart to continue browsing.",
+  "store/b2b-quotes.quote-locking.return-to-checkout": "Return to Checkout",
+  "store/b2b-quotes.quote-locking.clear-cart": "Clear Cart"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -71,5 +71,9 @@
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
   "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
-  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change",
+  "store/b2b-quotes.quote-locking.title": "Quote in Use",
+  "store/b2b-quotes.quote-locking.message": " Your cart currently contains items from a quote and therefore cannot be modified. You may either return to checkout or clear your cart to continue browsing.",
+  "store/b2b-quotes.quote-locking.return-to-checkout": "Return to Checkout",
+  "store/b2b-quotes.quote-locking.clear-cart": "Clear Cart"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -71,5 +71,9 @@
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
   "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
-  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change",
+  "store/b2b-quotes.quote-locking.title": "Quote in Use",
+  "store/b2b-quotes.quote-locking.message": " Your cart currently contains items from a quote and therefore cannot be modified. You may either return to checkout or clear your cart to continue browsing.",
+  "store/b2b-quotes.quote-locking.return-to-checkout": "Return to Checkout",
+  "store/b2b-quotes.quote-locking.clear-cart": "Clear Cart"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -71,5 +71,9 @@
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
   "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
-  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change",
+  "store/b2b-quotes.quote-locking.title": "Quote in Use",
+  "store/b2b-quotes.quote-locking.message": " Your cart currently contains items from a quote and therefore cannot be modified. You may either return to checkout or clear your cart to continue browsing.",
+  "store/b2b-quotes.quote-locking.return-to-checkout": "Return to Checkout",
+  "store/b2b-quotes.quote-locking.clear-cart": "Clear Cart"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -71,5 +71,9 @@
   "store/b2b-quotes.quote-details.original-price.title": "Original Price",
   "store/b2b-quotes.quote-details.quote-price.title": "Quoted Price",
   "store/b2b-quotes.quote-details.quoted-subtotal.title": "Quoted Subtotal",
-  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change"
+  "store/b2b-quotes.quote-details.expiration-date-change.title": "Expiration Date Change",
+  "store/b2b-quotes.quote-locking.title": "Quote in Use",
+  "store/b2b-quotes.quote-locking.message": " Your cart currently contains items from a quote and therefore cannot be modified. You may either return to checkout or clear your cart to continue browsing.",
+  "store/b2b-quotes.quote-locking.return-to-checkout": "Return to Checkout",
+  "store/b2b-quotes.quote-locking.clear-cart": "Clear Cart"
 }

--- a/react/B2BQuotesLockingModal.tsx
+++ b/react/B2BQuotesLockingModal.tsx
@@ -1,0 +1,3 @@
+import B2BQuotesLockingModal from './components/B2BQuotesLockingModal'
+
+export default B2BQuotesLockingModal

--- a/react/components/B2BQuotesLockingModal.tsx
+++ b/react/components/B2BQuotesLockingModal.tsx
@@ -1,0 +1,166 @@
+import React, { Fragment, useEffect, useState } from 'react'
+import { Modal, Button } from 'vtex.styleguide'
+import { defineMessages, useIntl } from 'react-intl'
+import { useRuntime } from 'vtex.render-runtime'
+import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
+import { useMutation, useQuery } from 'react-apollo'
+import { OrderForm } from 'vtex.order-manager'
+
+import CLEAR_CART from '../graphql/clearCartMutation.graphql'
+import GET_ORDERFORM from '../graphql/orderForm.gql'
+import ORDERFORM_CUSTOM_DATA from '../graphql/setOrderFormCustomData.graphql'
+
+const storePrefix = 'store/b2b-quotes.'
+
+const messages = defineMessages({
+  title: {
+    id: `${storePrefix}quote-locking.title`,
+  },
+  message: {
+    id: `${storePrefix}quote-locking.message`,
+  },
+  returnToCheckout: {
+    id: `${storePrefix}quote-locking.return-to-checkout`,
+  },
+  clearCart: {
+    id: `${storePrefix}quote-locking.clear-cart`,
+  },
+})
+
+const useCheckout = () => {
+  const { url: checkoutUrl, major } = useCheckoutURL()
+  const { navigate, rootPath = '' } = useRuntime()
+
+  const goToCheckout = (url: string) => {
+    if (major > 0 && url === checkoutUrl) {
+      navigate({ to: url })
+    } else {
+      window.location.href = `${rootPath}${url}`
+    }
+  }
+
+  return goToCheckout
+}
+
+const B2BQuotesLockingModal = () => {
+  const { formatMessage } = useIntl()
+  const [open, setOpen] = useState(false)
+  const goToCheckout = useCheckout()
+  const { url: checkoutUrl } = useCheckoutURL()
+  const [clearCart] = useMutation(CLEAR_CART)
+  const [setOrderFormCustomData] = useMutation(ORDERFORM_CUSTOM_DATA)
+  const [loading, setLoading] = useState(false)
+  const { setOrderForm }: OrderFormContext = OrderForm.useOrderForm()
+  const { data: orderFormData } = useQuery(GET_ORDERFORM, {
+    ssr: false,
+    fetchPolicy: 'network-only',
+  })
+
+  const handleClearCart = async () => {
+    setLoading(true)
+    const { orderForm } = orderFormData
+    const { orderFormId } = orderForm
+
+    try {
+      await clearCart({
+        variables: {
+          orderFormId,
+        },
+      })
+      await setOrderFormCustomData({
+        variables: {
+          orderFormId,
+          appId: 'b2b-quotes-graphql',
+          value: 0,
+          field: 'quoteId',
+        },
+      })
+    } catch (e) {
+      console.error(e)
+    }
+
+    setLoading(false)
+    setOpen(false)
+    setOrderForm({
+      ...orderForm,
+      items: [],
+    })
+  }
+
+  const handleReturnToCheckout = () => {
+    setOpen(false)
+    goToCheckout(checkoutUrl)
+  }
+
+  useEffect(() => {
+    if (!orderFormData) {
+      return
+    }
+
+    const { orderForm } = orderFormData
+    const { customData, items } = orderForm
+
+    if (!customData?.customApps) {
+      return
+    }
+
+    const index = customData.customApps.findIndex((item: any) => {
+      return item.id === 'b2b-quotes-graphql'
+    })
+
+    const { quoteId } = customData.customApps[index].fields
+
+    if (
+      index !== -1 &&
+      quoteId &&
+      parseInt(quoteId, 10) !== 0 &&
+      items?.length > 0
+    ) {
+      setOpen(true)
+    }
+  }, [orderFormData])
+
+  return (
+    <Fragment>
+      {open && (
+        <Modal
+          onClose={() => handleClearCart()}
+          closeOnEsc={false}
+          showCloseButton={false}
+          closeOnOverlayClick={false}
+          isOpen={open}
+          showCloseIcon={false}
+          bottomBar={
+            <div className="flex-s w-100-s items-center-s flex-column-s flex-column-reverse-s justify-end-m flex-row-m">
+              <span className="mr4 ">
+                <Button
+                  isLoading={loading}
+                  variation="tertiary"
+                  onClick={handleClearCart}
+                >
+                  {formatMessage(messages.clearCart)}
+                </Button>
+              </span>
+              <span>
+                <Button
+                  disabled={loading}
+                  variation="primary"
+                  onClick={handleReturnToCheckout}
+                >
+                  {formatMessage(messages.returnToCheckout)}
+                </Button>
+              </span>
+            </div>
+          }
+        >
+          <div>
+            <h1>{formatMessage(messages.title)}</h1>
+            <p>{formatMessage(messages.message)}</p>
+          </div>
+        </Modal>
+      )}
+    </Fragment>
+  )
+}
+
+export default B2BQuotesLockingModal

--- a/react/graphql/setOrderFormCustomData.graphql
+++ b/react/graphql/setOrderFormCustomData.graphql
@@ -9,7 +9,7 @@ mutation setOrderFormCustomData(
     appId: $appId
     field: $field
     value: $value
-  ) {
+  ) @context(provider: "vtex.store-graphql") {
     orderFormId
     customData {
       customApps {

--- a/react/graphql/setOrderFormCustomData.graphql
+++ b/react/graphql/setOrderFormCustomData.graphql
@@ -1,0 +1,22 @@
+mutation setOrderFormCustomData(
+  $appId: String
+  $field: String
+  $value: String
+  $orderFormId: String
+) {
+  setOrderFormCustomData(
+    orderFormId: $orderFormId
+    appId: $appId
+    field: $field
+    value: $value
+  ) {
+    orderFormId
+    customData {
+      customApps {
+        fields
+        id
+        major
+      }
+    }
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -5,6 +5,10 @@
   "quotes-table": {
     "component": "QuotesTable"
   },
+  "quotes-locking-modal": {
+    "component": "B2BQuotesLockingModal"
+  },
+
   "store.create-b2b-quote": {
     "required": ["quote-details"]
   },


### PR DESCRIPTION
#### What problem is this solving?

When the user has a quote in their orderform he is able to handle their cart as he wants. So the solution is creating a modal component that verifies if the quoteId is on the orderForm and locks by opening the modal component if the user tries to browse other pages instead of the checkout page.


#### How to test it?

Workspace:  [https://b2borg--sandboxusdev.myvtex.com/](https://b2borg--sandboxusdev.myvtex.com/)

1) Access your account and go to quotes [https://b2borg--sandboxusdev.myvtex.com/b2b-quotes](https://b2borg--sandboxusdev.myvtex.com/b2b-quotes)

2) Select one quote and then click on "use quote"

3) You'll redirect to checkout, so, click on the "continue shopping" or on VTEX logo to return to the home page

4) The modal will show with these options:

![image](https://user-images.githubusercontent.com/5812946/159985821-1011b5d3-435b-423a-870c-b549f69939e4.png)

Test both options, return to checkout, and clear cart.