### PR TITLE
[B2BQUOTES-50] [B2BQUOTES-53] [B2BQUOTES-54] [B2BQUOTES-55] [B2BQUOTES-56] [B2BQUOTES-57]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix on discounts negative
+- NaN total when quoted price is empty
+- fix on handling quantity
+- fix on difference between input and slider discount
+- fix on slider discount bar
+- fix on orderform graphql query by adding "network-only"
+
 ## [1.0.0] - 2022-04-14
 
 ### Added

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -454,11 +454,22 @@ const QuoteDetails: FunctionComponent = () => {
     let newSubtotal = 0
     const newItems = quoteState.items.map((item: QuoteItem) => {
       if (item.id === itemId) {
-        newSubtotal += item.sellingPrice * +event.target.value
+        let quantity =
+          !new RegExp(/[^\d]/g).test(event.target.value) && event.target.value
+            ? parseInt(event.target.value, 10)
+            : 1
+
+        if (quantity <= 0) {
+          quantity = 1
+        } else if (quantity > 50) {
+          quantity = 50
+        }
+
+        newSubtotal += item.sellingPrice * quantity
 
         return {
           ...item,
-          quantity: +event.target.value,
+          quantity,
         }
       }
 

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -423,7 +423,11 @@ const QuoteDetails: FunctionComponent = () => {
   ) => ChangeEventHandler<HTMLInputElement> = (itemId) => (event) => {
     const newItems = quoteState.items.map((item: QuoteItem) => {
       if (item.id === itemId) {
-        const newPrice = ((event.target.value as unknown) as number) * 100
+        let newPrice = ((event.target.value as unknown) as number) * 100
+
+        if (newPrice > item.listPrice) {
+          newPrice = item.listPrice
+        }
 
         return {
           ...item,

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -198,7 +198,7 @@ const QuoteDetails: FunctionComponent = () => {
   const {
     data: orderFormData,
     refetch: refetchOrderForm,
-  } = useQuery(GET_ORDERFORM, { ssr: false })
+  } = useQuery(GET_ORDERFORM, { ssr: false, fetchPolicy: 'network-only' })
 
   const { data: orderAuthData } = useQuery(GET_AUTH_RULES, { ssr: false })
   const {

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -911,8 +911,11 @@ const QuoteDetails: FunctionComponent = () => {
                               <span className="tr w-100">
                                 <FormattedCurrency
                                   value={
-                                    (rowData.sellingPrice * rowData.quantity) /
-                                    100
+                                    rowData.sellingPrice
+                                      ? (rowData.sellingPrice *
+                                          rowData.quantity) /
+                                        100
+                                      : 0
                                   }
                                 />
                               </span>

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -45,6 +45,7 @@ import CLEAR_CART from '../graphql/clearCartMutation.graphql'
 import storageFactory from '../utils/storage'
 
 const localStore = storageFactory(() => localStorage)
+const MAX_DISCOUNT_PERCENTAGE = 80
 
 let isAuthenticated =
   JSON.parse(String(localStore.getItem('b2bquotes_isAuthenticated'))) ?? false
@@ -122,7 +123,10 @@ const QuoteDetails: FunctionComponent = () => {
 
   const [orderFormState, setOrderFormState] = useState('')
   const [noteState, setNoteState] = useState('')
-  const [maxDiscountState, setMaxDiscountState] = useState(100)
+  const [maxDiscountState, setMaxDiscountState] = useState(
+    MAX_DISCOUNT_PERCENTAGE
+  )
+
   const [discountState, setDiscountState] = useState(0)
   const [updatingQuoteState, setUpdatingQuoteState] = useState(false)
   const [usingQuoteState, setUsingQuoteState] = useState(false)
@@ -190,7 +194,7 @@ const QuoteDetails: FunctionComponent = () => {
       ruleCollection.find(
         (collection: any) =>
           collection?.trigger?.effect?.description === 'DenyEffect'
-      )?.trigger?.condition?.greatherThan ?? 100
+      )?.trigger?.condition?.greatherThan ?? MAX_DISCOUNT_PERCENTAGE
 
     setMaxDiscountState(maxDiscountPercentage)
   }, [orderAuthData])
@@ -433,7 +437,8 @@ const QuoteDetails: FunctionComponent = () => {
           ...item,
           sellingPrice: newPrice,
           error:
-            !newPrice || newPrice / item.listPrice < maxDiscountState / 100
+            !newPrice ||
+            newPrice / item.listPrice < (100 - maxDiscountState) / 100
               ? true
               : undefined, // setting error to false will cause create/update mutation to error
         }

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -45,7 +45,7 @@ import CLEAR_CART from '../graphql/clearCartMutation.graphql'
 import storageFactory from '../utils/storage'
 
 const localStore = storageFactory(() => localStorage)
-const MAX_DISCOUNT_PERCENTAGE = 80
+const MAX_DISCOUNT_PERCENTAGE = 99
 
 let isAuthenticated =
   JSON.parse(String(localStore.getItem('b2bquotes_isAuthenticated'))) ?? false

--- a/react/components/QuoteDetails.tsx
+++ b/react/components/QuoteDetails.tsx
@@ -70,6 +70,52 @@ const initialState = {
   viewedBySales: false,
 }
 
+const PercentageDiscount = ({
+  updatingSubtotal,
+  originalSubtotal,
+  maxDiscountState,
+  discountState,
+  handlePercentageDiscount,
+}: any) => {
+  if (
+    discountState === 0 ||
+    (updatingSubtotal !== undefined &&
+      originalSubtotal !== undefined &&
+      Math.round(100 - (updatingSubtotal / originalSubtotal) * 100) <=
+        maxDiscountState)
+  ) {
+    return (
+      <Fragment>
+        <div className="mt5">
+          <Slider
+            onChange={([value]: [number]) => {
+              handlePercentageDiscount(value)
+            }}
+            min={0}
+            max={maxDiscountState}
+            step={1}
+            disabled={false}
+            defaultValues={[0]}
+            alwaysShowCurrentValue
+            formatValue={(a: number) => `${a}%`}
+            value={discountState}
+          />
+        </div>
+
+        <div className="mt1">
+          <FormattedMessage id="store/b2b-quotes.quote-details.apply-discount.help-text" />
+        </div>
+      </Fragment>
+    )
+  }
+
+  return (
+    <div className="mt1">
+      <FormattedMessage id="store/b2b-quotes.quote-details.apply-discount.disabled-message" />
+    </div>
+  )
+}
+
 const QuoteDetails: FunctionComponent = () => {
   const {
     culture,
@@ -566,45 +612,6 @@ const QuoteDetails: FunctionComponent = () => {
     return <h3 className="t-heading-3 mb8">{quoteState.referenceName}</h3>
   }
 
-  const renderPercentageDiscount = () => {
-    if (
-      updatingSubtotal &&
-      originalSubtotal &&
-      Math.round(100 - (updatingSubtotal / originalSubtotal) * 100) <=
-        maxDiscountState
-    ) {
-      return (
-        <Fragment>
-          <div className="mt5">
-            <Slider
-              onChange={([value]: [number]) => {
-                handlePercentageDiscount(value)
-              }}
-              min={0}
-              max={maxDiscountState}
-              step={1}
-              disabled={false}
-              defaultValues={[0]}
-              alwaysShowCurrentValue
-              formatValue={(a: number) => `${a}%`}
-              value={discountState}
-            />
-          </div>
-
-          <div className="mt1">
-            <FormattedMessage id="store/b2b-quotes.quote-details.apply-discount.help-text" />
-          </div>
-        </Fragment>
-      )
-    }
-
-    return (
-      <div className="mt1">
-        <FormattedMessage id="store/b2b-quotes.quote-details.apply-discount.disabled-message" />
-      </div>
-    )
-  }
-
   const renderQuoteSaveButtons = () => {
     if (isNewQuote) {
       return (
@@ -950,7 +957,13 @@ const QuoteDetails: FunctionComponent = () => {
                         <FormattedMessage id="store/b2b-quotes.quote-details.apply-discount.title" />
                       </h3>
                       <div className="pa5">
-                        {renderPercentageDiscount()}
+                        <PercentageDiscount
+                          updatingSubtotal={updatingSubtotal}
+                          originalSubtotal={originalSubtotal}
+                          maxDiscountState={maxDiscountState}
+                          discountState={discountState}
+                          handlePercentageDiscount={handlePercentageDiscount}
+                        />
                         {maxDiscountState < 100 && (
                           <div className="mt1">
                             <FormattedMessage


### PR DESCRIPTION
#### What problem is this solving?
This PR is solving a couple of minor issues found by QA team.

Environment to test: [https://b2borg--sandboxusdev.myvtex.com/](https://b2borg--sandboxusdev.myvtex.com/)

Quotes Page: [https://b2borg--sandboxusdev.myvtex.com/b2b-quotes](https://b2borg--sandboxusdev.myvtex.com/b2b-quotes)

Create Quote Page: [https://b2borg--sandboxusdev.myvtex.com/b2b-quotes/create](https://b2borg--sandboxusdev.myvtex.com/b2b-quotes/create)

## B2BQUOTES-50

[Ticket](https://vtex-dev.atlassian.net/browse/B2BQUOTES-50)

Steps to Replicate:
1. Add product to cart
2. Open cart
3. Click Create Quote button
4. Click Request Quote button
5. Search for same/different product again
6. Open cart
7. Click Create Quote button

Actual Result: Product is not showing in create quote page
Note: Sometimes if we reload then it shows product in create quote page

Expected Result: Product should show in create quote page


## B2BQUOTES-53

[Ticket](https://vtex-dev.atlassian.net/browse/B2BQUOTES-53)

If sales user removes quoted price, then total is shown as $NaN

![image](https://user-images.githubusercontent.com/5812946/164545520-9cba7635-7cb4-478e-905a-af80ac7df700.png)

## B2BQUOTES-54

[Ticket](https://vtex-dev.atlassian.net/browse/B2BQUOTES-54)

Default value for product quantity should be 1

## B2BQUOTES-55
[Ticket](https://vtex-dev.atlassian.net/browse/B2BQUOTES-55)

Steps to Replicate:
1. Create a quote for a product which has discount
2. Try to update Quoted price with greater than original price
3. Save Quote

Actual Result: Able to save quote successfully
Expected Result: Quoted price should be less than or equal to the original price

![image](https://user-images.githubusercontent.com/5812946/164545862-7eb0802c-193c-4112-a85b-76ad4772a0cc.png)

## B2BQUOTES-56
[Ticket](https://vtex-dev.atlassian.net/browse/B2BQUOTES-56)

Scenario 1:
Steps to Replicate: [PFA-1 (discount_slider.mov)]
1. Create a Quote as Sales user
2. Open the Quote
3. Select discount using discount slider

Expected Result: Discount Slider should be smooth
Actual Result: Discount Slider gets flickered


Scenario 2:
Steps to Replicate: [PFA-2 (flicker.mov)]

Create a Quote as Sales user

Open the Quote

Select 0% discount using discount slider

Expected Result: Discount Slider should be smooth
Actual Result: Discount Slider gets flickered

***See the attachments on the ticket to get more details***

## B2BQUOTES-57
[Ticket](https://vtex-dev.atlassian.net/browse/B2BQUOTES-57)

Quotes Discount is not working fine in productusqa whereas in b2bstoreqa it works fine [PFA]

Add Discount By Input TextBox - 1620.00 shows error ( There are some discounts higher than allowed.) [PFA-1]
Add Discount By Slider - 70% - Quote Subtotal - 1620.00 [PFA-2]

![image](https://user-images.githubusercontent.com/5812946/164546375-ff94fc16-6f71-464d-be6d-2cfbf6c9c5a4.png)

![image](https://user-images.githubusercontent.com/5812946/164546401-f928ed44-d72b-48a9-9c0e-f0c67ad51335.png)

