### PR TITLE
Fix SonarCloud action pull_request_target

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,13 +9,25 @@ on:
       - feature/*
       - fix/*
       - chore/*
-  pull_request:
-    types: [opened, synchronize, reopened]
-    
+  pull_request_target:
+    branches:
+    - master
+    - main
+    types:
+    - labeled    
+
 jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ github.event_name == 'push' ||
+            ( 
+              github.event_name == 'pull_request_target' &&
+              contains(github.event.label.name, 'safe to test')
+            )
+         }}      
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -39,6 +51,12 @@ jobs:
         
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
+        with:
+          # SonarCloud doesn't treat pull_request_target, so we need this
+          args: >
+            -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} 
+            -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} 
+            -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }} 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
#### What problem is this solving?

Fix the SonarCloud action to make possible run SonarCloud analysis from external users after check the code and add the label  `safe to test`.