### PR TITLE
Fix render error when there are no quotes in the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Filter error if no quotes have been created yet
+
 ## [1.1.0] - 2022-05-19
 
 ### Added

--- a/react/components/QuotesTable.tsx
+++ b/react/components/QuotesTable.tsx
@@ -262,6 +262,8 @@ const QuotesTable: FunctionComponent<QuotesTableProps> = ({
     value: OrgAndCC
     onChange: any
   }) => {
+    if (!quotes.length) return null
+
     let orgId = value?.organizationId || ''
 
     if (!showOrganizationFilter) {

--- a/react/components/QuotesTable.tsx
+++ b/react/components/QuotesTable.tsx
@@ -12,6 +12,7 @@ import type { OrgAndCC } from './OrganizationAndCostCenterFilter'
 
 interface QuotesTableProps {
   permissions: string[]
+  mainOrganizationId: string
   quotes: QuoteSimple[]
   page: number
   pageSize: number
@@ -55,6 +56,7 @@ export const labelTypeByStatusMap: Record<string, string> = {
 
 const QuotesTable: FunctionComponent<QuotesTableProps> = ({
   permissions,
+  mainOrganizationId,
   quotes,
   page,
   pageSize,
@@ -262,12 +264,10 @@ const QuotesTable: FunctionComponent<QuotesTableProps> = ({
     value: OrgAndCC
     onChange: any
   }) => {
-    if (!quotes.length) return null
-
     let orgId = value?.organizationId || ''
 
     if (!showOrganizationFilter) {
-      orgId = quotes[0].organization
+      orgId = mainOrganizationId
     }
 
     return (

--- a/react/components/QuotesTableContainer.tsx
+++ b/react/components/QuotesTableContainer.tsx
@@ -8,13 +8,14 @@ import { Layout, PageHeader, PageBlock, Spinner } from 'vtex.styleguide'
 import { useSessionResponse } from '../utils/helpers'
 import QuotesTable from './QuotesTable'
 import GET_QUOTES from '../graphql/getQuotes.graphql'
+import GET_MAIN_ORGANIZATION from '../graphql/getMainOrganization.graphql'
 import GET_PERMISSIONS from '../graphql/getPermissions.graphql'
 import storageFactory from '../utils/storage'
 
 const localStore = storageFactory(() => localStorage)
 
 let isAuthenticated =
-  JSON.parse(String(localStore.getItem('orderquote_isAuthenticated'))) ?? false
+  JSON.parse(String(localStore.getItem('b2bquotes_isAuthenticated'))) ?? false
 
 const QuotesTableContainer: FunctionComponent = () => {
   const { navigate, rootPath } = useRuntime()
@@ -46,7 +47,7 @@ const QuotesTableContainer: FunctionComponent = () => {
       sessionResponse?.namespaces?.profile?.isAuthenticated?.value === 'true'
 
     localStore.setItem(
-      'orderquote_isAuthenticated',
+      'b2bquotes_isAuthenticated',
       JSON.stringify(isAuthenticated)
     )
   }
@@ -58,6 +59,13 @@ const QuotesTableContainer: FunctionComponent = () => {
       skip: !isAuthenticated,
     }
   )
+
+  const {
+    data: mainOrganizationData,
+    loading: mainOrganizationLoading,
+  } = useQuery(GET_MAIN_ORGANIZATION, {
+    ssr: false,
+  })
 
   const { data, loading, refetch } = useQuery(GET_QUOTES, {
     fetchPolicy: 'network-only',
@@ -279,19 +287,17 @@ const QuotesTableContainer: FunctionComponent = () => {
       (permission: string) => permission.indexOf('access-quotes') >= 0
     )
   ) {
+    const message = !isAuthenticated ? (
+      <FormattedMessage id="store/b2b-quotes.error.notAuthenticated" />
+    ) : (
+      <FormattedMessage id="store/b2b-quotes.error.notPermitted" />
+    )
+
     return (
       <Layout fullWidth>
         <div className="mw9 center">
           <Layout fullWidth pageHeader={<QuotesTablePageHeader />}>
-            <PageBlock>
-              {permissionsLoading ? (
-                <Spinner />
-              ) : !isAuthenticated ? (
-                <FormattedMessage id="store/b2b-quotes.error.notAuthenticated" />
-              ) : (
-                <FormattedMessage id="store/b2b-quotes.error.notPermitted" />
-              )}
-            </PageBlock>
+            <PageBlock>{permissionsLoading ? <Spinner /> : message}</PageBlock>
           </Layout>
         </div>
       </Layout>
@@ -304,11 +310,14 @@ const QuotesTableContainer: FunctionComponent = () => {
         <Layout fullWidth pageHeader={<QuotesTablePageHeader />}>
           <QuotesTable
             quotes={data?.getQuotes?.data ?? []}
+            mainOrganizationId={
+              mainOrganizationData?.getOrganizationByIdStorefront?.id
+            }
             permissions={permissionsData.checkUserPermission.permissions}
             page={paginationState.page}
             pageSize={paginationState.pageSize}
             total={data?.getQuotes?.pagination?.total ?? 0}
-            loading={loading}
+            loading={loading || permissionsLoading || mainOrganizationLoading}
             handlePrevClick={handlePrevClick}
             handleNextClick={handleNextClick}
             filterStatements={filterState.filterStatements}

--- a/react/graphql/getMainOrganization.graphql
+++ b/react/graphql/getMainOrganization.graphql
@@ -1,0 +1,6 @@
+query GetMainOrganization {
+  getOrganizationByIdStorefront
+    @context(provider: "vtex.b2b-organizations-graphql") {
+    id
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

QA team identified a render error that occurs when there are no quotes in the table (for instance if you have a new organization that hasn't created any quotes yet). This happened because a function was attempting to get the organization ID from the first quote in the list.

This PR fixes the error and improves the logic by using the `getOrganizationByIdStorefront` query to get the user's main organization, instead of getting it from the first quote in the list (the query returns the user's assigned organization if no ID variable is specified).  

#### How to test it?

New version linked in https://b2bsuite--sandboxusdev.myvtex.com