### PR TITLE
[B2BQUOTES-69] Add permission configuration to access all sales channel quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Permission to `Access All Sales Channels' Quotes and Carts` option for roles
+
 ## [1.4.1] - 2022-08-19
 
 ### Fixed

--- a/vtex.storefront-permissions/configuration.json
+++ b/vtex.storefront-permissions/configuration.json
@@ -25,6 +25,19 @@
       "roles": ["customer-admin", "sales-manager"]
     },
     {
+      "label": "Access All Sales Channels' Quotes and Carts",
+      "value": "access-quotes-all-saleschannel",
+      "roles": [
+        "store-admin",
+        "sales-admin",
+        "sales-manager",
+        "sales-representative",
+        "customer-admin",
+        "customer-approver",
+        "customer-buyer"
+      ]
+    },
+    {
       "label": "Access All Quotes and Carts",
       "value": "access-quotes-all",
       "roles": ["store-admin", "sales-admin"]


### PR DESCRIPTION
#### What problem is this solving?

Add new permission to `Access All Sales Channels' Quotes and Carts`. Can toggle permission on and off for different roles. To note, this option is automatically enabled for all roles on initial installation only. Roles that have already been configured will need to enable this option manually.

#### How to test it?

Test in workspace [anna](https://anna--b2bstoreqa.myvtex.com/) in account b2bstoreqa.

#### Screenshots or example usage:
<img width="977" alt="Screen Shot 2022-08-23 at 12 42 15 PM" src="https://user-images.githubusercontent.com/53097865/186220892-037e55ea-1ab1-4b46-b51d-a6c11a98f8fb.png">

<img width="970" alt="Screen Shot 2022-08-23 at 1 07 53 PM" src="https://user-images.githubusercontent.com/53097865/186221151-be0cf86a-0638-441c-a05a-906869c979d7.png">


#### Related to / Depends on
This permission is implemented in a [PR](https://github.com/vtex-apps/b2b-quotes-graphql/pull/23) for vtex.b2b-quotes-graphql.