### PR TITLE
Fix status filter locale in my quotes page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed status filter locale in my quotes page
+
 ### Removed
 - [ENGINEERS-1247] - Disable cypress tests in PR level
 

--- a/react/components/QuotesTable.tsx
+++ b/react/components/QuotesTable.tsx
@@ -233,7 +233,9 @@ const QuotesTable: FunctionComponent<QuotesTableProps> = ({
             <div className="mb3" key={`status-select-object-${opt}-${index}`}>
               <Checkbox
                 checked={value ? value[opt] : initialValue[opt]}
-                label={opt}
+                label={formatMessage(
+                  statusMessages[opt as keyof typeof statusMessages]
+                )}
                 name="status-checkbox-group"
                 onChange={() => {
                   const newValue = toggleValueByKey(`${opt}`)
@@ -343,7 +345,7 @@ const QuotesTable: FunctionComponent<QuotesTableProps> = ({
             status: {
               label: formatMessage(tableMessages.statusFilter),
               renderFilterLabel: (st: any) => {
-                if (!st || !st.object) {
+                if (!st?.object) {
                   // you should treat empty object cases only for alwaysVisibleFilters
                   return formatMessage(tableMessages.filtersAll)
                 }
@@ -382,7 +384,7 @@ const QuotesTable: FunctionComponent<QuotesTableProps> = ({
               organizationAndCostCenter: {
                 label: formatMessage(tableMessages.organizationAndCostCenter),
                 renderFilterLabel: (st: any) => {
-                  if (!st || !st.object) {
+                  if (!st?.object) {
                     // you should treat empty object cases only for alwaysVisibleFilters
                     return formatMessage(tableMessages.filtersAll)
                   }


### PR DESCRIPTION
#### What problem is this solving?

This solves a bug where status filter in quotes page was not properly translated. 

#### How to test it?

1. Login to the store
2. Create a quote if none exists
3. Go to My Quotes page
4. Click on the status filter and check all status checkboxes are shown in the expected language

[Workspace](https://enzo--b2bstoreqa.myvtex.com)

#### Screenshots or example usage:
Before the fix:
![Captura de Tela 2023-05-05 às 15 23 26](https://user-images.githubusercontent.com/131273915/236538445-34503070-d394-4dd9-8e2f-54eff24c165e.png)

After the fix:
![Captura de Tela 2023-05-05 às 15 24 55](https://user-images.githubusercontent.com/131273915/236538360-f7f47436-251b-40f2-8775-4c0694e49bc0.png)

#### Describe alternatives you've considered, if any.
N/A

#### Related to / Depends on
N/A

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Zui38gKVIIY5KVL40l/giphy.gif)
