### PR TITLE
fix: change to use price instead of list price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix subtotal price in quote details and price used in discount calculation
+- Change to use price instead of list price in quote features(view, discount and update selling price)
 
 ## [1.5.4] - 2023-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix subtotal price in quote details
-  
+- Fix subtotal price in quote details and price used in discount calculation
+
 ## [1.5.4] - 2023-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.4] - 2023-05-08
 
 ### Fixed
+
 - Fixed status filter locale in my quotes page
 
 ### Removed
+
 - [ENGINEERS-1247] - Disable cypress tests in PR level
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix subtotal price in quote details
+  
 ## [1.5.4] - 2023-05-08
 
 ### Fixed

--- a/react/components/QuoteDetails/QuoteDetails.tsx
+++ b/react/components/QuoteDetails/QuoteDetails.tsx
@@ -402,9 +402,7 @@ const QuoteDetails: FunctionComponent = () => {
       }
     } else {
       quoteState.items.forEach((item: QuoteItem) => {
-        const newSellingPrice = Math.round(
-          item.listPrice * ((100 - percent) / 100)
-        )
+        const newSellingPrice = Math.round(item.price * ((100 - percent) / 100))
 
         newSubtotal += newSellingPrice * item.quantity
 

--- a/react/components/QuoteDetails/QuoteDetails.tsx
+++ b/react/components/QuoteDetails/QuoteDetails.tsx
@@ -1,25 +1,25 @@
 /* eslint-disable react/display-name */
-import type { FunctionComponent, ChangeEventHandler } from 'react'
-import React, { useState, useEffect, useContext, Fragment } from 'react'
-import { useIntl, FormattedMessage } from 'react-intl'
-import { useQuery, useMutation } from 'react-apollo'
+import type { ChangeEventHandler, FunctionComponent } from 'react'
+import React, { Fragment, useContext, useEffect, useState } from 'react'
+import { FormattedMessage, useIntl } from 'react-intl'
+import { useMutation, useQuery } from 'react-apollo'
 import { useRuntime } from 'vtex.render-runtime'
 import {
-  Layout,
-  PageHeader,
-  PageBlock,
-  Spinner,
   Button,
+  DatePicker,
+  Layout,
+  PageBlock,
+  PageHeader,
+  Spinner,
   Textarea,
   ToastContext,
-  DatePicker,
 } from 'vtex.styleguide'
 import { useCheckoutURL } from 'vtex.checkout-resources/Utils'
 import { OrderForm } from 'vtex.order-manager'
 
 import { quoteMessages } from '../../utils/messages'
 import { arrayShallowEqual } from '../../utils/shallowEquals'
-import { useSessionResponse, initQuoteFromOrderForm } from '../../utils/helpers'
+import { initQuoteFromOrderForm, useSessionResponse } from '../../utils/helpers'
 import useCheckout from '../../modules/checkoutHook'
 import GET_PERMISSIONS from '../../graphql/getPermissions.graphql'
 import GET_QUOTE from '../../graphql/getQuote.graphql'
@@ -327,16 +327,15 @@ const QuoteDetails: FunctionComponent = () => {
       if (item.id === itemId) {
         let newPrice = ((event.target.value as unknown) as number) * 100
 
-        if (newPrice > item.listPrice) {
-          newPrice = item.listPrice
+        if (newPrice > item.price) {
+          newPrice = item.price
         }
 
         return {
           ...item,
           sellingPrice: newPrice,
           error:
-            !newPrice ||
-            newPrice / item.listPrice < (100 - maxDiscountState) / 100
+            !newPrice || newPrice / item.price < (100 - maxDiscountState) / 100
               ? true
               : undefined, // setting error to false will cause create/update mutation to error
         }

--- a/react/components/QuoteDetails/QuoteDetails.tsx
+++ b/react/components/QuoteDetails/QuoteDetails.tsx
@@ -434,7 +434,7 @@ const QuoteDetails: FunctionComponent = () => {
     }
 
     const price = quoteState.items.reduce(
-      (sum: number, item: QuoteItem) => sum + item.listPrice * item.quantity,
+      (sum: number, item: QuoteItem) => sum + item.price * item.quantity,
       0
     )
 


### PR DESCRIPTION
#### What problem is this solving?

There is a bug in quote details where the subtotal price being shown is not the base price.

#### How to test it?

- Product Acer Aspire TC-885-UA92 Desktop - Windows 10 has final price of R$ 139,50 (based price + discount) and list price of R$ 3.000,00.
- Add the Acer Aspire TC-885-UA92 Desktop - Windows 10 to the cart.
- Create a quote from mini-cart
- You will see Subtotal original R$ 3.000,00 and Desconto percentual 95%.
- It should b2 R$ 139,50 and Desconto percentual 0%

[Workspace](https://b2bteam1210--b2bstore005.myvtex.com/)

#### Screenshots or example usage:

![image](https://github.com/vtex-apps/b2b-quotes/assets/5332361/5560d23d-0090-4e60-898b-33744d39cb93)

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media2.giphy.com/media/URoLoCo1s9jm8/giphy.gif)
