### PR TITLE
Use Quote Metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 + ### Added
 + - Quotation created metrics sent to Analytics Redshift
++ - Use quote metrics sent to Analytics Redshift
 
 ## [1.5.5] - 2023-06-29
 

--- a/react/components/QuoteDetails/QuoteDetails.tsx
+++ b/react/components/QuoteDetails/QuoteDetails.tsx
@@ -38,7 +38,9 @@ import AlertMessage from './AlertMessage'
 import QuoteTable from './QuoteTable'
 import QuoteUpdateHistory from './QuoteUpdateHistory'
 import { Status } from '../../utils/status'
-import { sendMetric } from '../../utils/metrics'
+import { sendCreateQuoteMetric } from '../../utils/metrics/createQuote'
+import type { UseQuoteMetricsParams } from '../../utils/metrics/useQuote'
+import { sendUseQuoteMetric } from '../../utils/metrics/useQuote'
 
 const localStore = storageFactory(() => localStorage)
 const MAX_DISCOUNT_PERCENTAGE = 99
@@ -207,7 +209,7 @@ const QuoteDetails: FunctionComponent = () => {
             account,
           }
 
-          sendMetric(metricsParam)
+          sendCreateQuoteMetric(metricsParam)
 
           toastMessage(quoteMessages.createSuccess)
           handleClearCart(orderForm.orderFormId).then(() => {
@@ -305,6 +307,14 @@ const QuoteDetails: FunctionComponent = () => {
         setUsingQuoteState(false)
       })
       .then(() => {
+        const metricsParam: UseQuoteMetricsParams = {
+          quoteState,
+          orderFormId: variables.orderFormId,
+          account,
+          sessionResponse,
+        }
+
+        sendUseQuoteMetric(metricsParam)
         goToCheckout(checkoutUrl)
         setUsingQuoteState(false)
       })

--- a/react/utils/metrics/metrics.ts
+++ b/react/utils/metrics/metrics.ts
@@ -1,0 +1,37 @@
+import axios from 'axios'
+
+const ANALYTICS_URL = 'https://rc.vtex.com/api/analytics/schemaless-events'
+
+type CreateQuoteMetric = {
+  kind: 'create-quote-ui-event'
+  description: 'Create Quotation Action - UI'
+}
+
+type UseQuoteMetric = {
+  kind: 'use-quote-ui-event'
+  description: 'Use Quotation Action - UI'
+}
+
+export type Metric = {
+  name: 'b2b-suite-buyerorg-data'
+  account: string
+} & (CreateQuoteMetric | UseQuoteMetric)
+
+export type SessionProfile = {
+  id: { value: string }
+  email: { value: string }
+}
+
+export type SessionResponse = {
+  namespaces: {
+    profile: SessionProfile
+  }
+}
+
+export const sendMetric = async (metric: Metric) => {
+  try {
+    await axios.post(ANALYTICS_URL, metric)
+  } catch (error) {
+    console.warn('Unable to log metrics', error)
+  }
+}

--- a/react/utils/metrics/useQuote.ts
+++ b/react/utils/metrics/useQuote.ts
@@ -24,9 +24,9 @@ export type UseQuoteMetricsParams = {
   sessionResponse: SessionResponse
 }
 
-const buildUseQuoteMetric = async (
+const buildUseQuoteMetric = (
   metricsParam: UseQuoteMetricsParams
-): Promise<UseQuoteMetric> => {
+): UseQuoteMetric => {
   const { quoteState, orderFormId, account, sessionResponse } = metricsParam
 
   const metric: UseQuoteMetric = {
@@ -56,9 +56,9 @@ export const sendUseQuoteMetric = async (
   metricsParam: UseQuoteMetricsParams
 ) => {
   try {
-    const metric = await buildUseQuoteMetric(metricsParam)
+    const metric = buildUseQuoteMetric(metricsParam)
 
-    sendMetric(metric)
+    await sendMetric(metric)
   } catch (error) {
     console.warn('Unable to log metrics', error)
   }

--- a/react/utils/metrics/useQuote.ts
+++ b/react/utils/metrics/useQuote.ts
@@ -1,0 +1,65 @@
+import type { Metric, SessionResponse } from './metrics'
+import { sendMetric } from './metrics'
+
+type UseQuoteFieldsMetric = {
+  quote_id: string
+  quote_reference_name: string
+  order_form_id: string
+  quote_creation_date: string
+  quote_use_date: string
+  creator_email: string
+  user_email: string
+  cost_center_name: string
+  buy_org_id: string
+  buy_org_name: string
+  quote_last_update: string
+}
+
+type UseQuoteMetric = Metric & { fields: UseQuoteFieldsMetric }
+
+export type UseQuoteMetricsParams = {
+  quoteState: Quote
+  orderFormId: string
+  account: string
+  sessionResponse: SessionResponse
+}
+
+const buildUseQuoteMetric = async (
+  metricsParam: UseQuoteMetricsParams
+): Promise<UseQuoteMetric> => {
+  const { quoteState, orderFormId, account, sessionResponse } = metricsParam
+
+  const metric: UseQuoteMetric = {
+    name: 'b2b-suite-buyerorg-data',
+    kind: 'use-quote-ui-event',
+    description: 'Use Quotation Action - UI',
+    account,
+    fields: {
+      buy_org_id: quoteState.organization,
+      buy_org_name: quoteState.organizationName,
+      cost_center_name: quoteState.costCenterName,
+      quote_id: quoteState.id,
+      quote_reference_name: quoteState.referenceName,
+      order_form_id: orderFormId,
+      quote_creation_date: quoteState.creationDate,
+      quote_use_date: new Date().toISOString(),
+      creator_email: quoteState.creatorEmail,
+      user_email: sessionResponse.namespaces?.profile?.email?.value,
+      quote_last_update: quoteState.lastUpdate,
+    },
+  }
+
+  return metric
+}
+
+export const sendUseQuoteMetric = async (
+  metricsParam: UseQuoteMetricsParams
+) => {
+  try {
+    const metric = await buildUseQuoteMetric(metricsParam)
+
+    sendMetric(metric)
+  } catch (error) {
+    console.warn('Unable to log metrics', error)
+  }
+}


### PR DESCRIPTION
#### What problem is this solving?

Sending metrics to Analytics when user uses a quotation in order to understand user behaviour through data.

#### How to test it?

Select a previous created quote and convert it to a cart (through "Usar Cotação" button). You can use https://takeda--b2bstore005.myvtex.com/deals for tests,

After one hour (maximum), data should appear in Analytics Redshift, into table "vtex"."schemaless"."b2b_suite_buyerorg_data_raw"


#### Screenshots or example usage:

Before use quote:
![image](https://github.com/vtex-apps/b2b-quotes/assets/1576737/38601a8d-c109-4720-8db6-1ce38d9a3a42)

After use quote:
![image](https://github.com/vtex-apps/b2b-quotes/assets/1576737/d6ef2fb1-79ff-406d-9fc4-e6b4e2d2c6d9)

Types:
```
type UseQuoteFieldsMetric = {
  quote_id: string
  quote_reference_name: string
  order_form_id: string
  quote_creation_date: string
  quote_use_date: string
  creator_email: string
  user_email: string
  cost_center_name: string
  buy_org_id: string
  buy_org_name: string
  quote_last_update: string
}

type UseQuoteMetric = {
  kind: 'use-quote-ui-event'
  description: 'Use Quotation Action - UI'
}

export type Metric = {
  name: 'b2b-suite-buyerorg-data'
  account: string
} & (CreateQuoteMetric | UseQuoteMetric)

type UseQuoteMetric = Metric & { fields: UseQuoteFieldsMetric }
```

Example of query and results:
```
SELECT
    payload.kind,
    payload.account,
    payload.fields.buy_org_name,
    payload.fields.cost_center_name,
    payload.fields.quote_id,
    payload.fields.quote_reference_name,
    payload.fields.order_form_id,
    payload.fields.quote_creation_date,
    payload.fields.quote_use_date,
    payload.fields.creator_email,
    payload.fields.user_email,
    payload.fields.cost_center_name,
    payload.fields.buy_org_id,
    payload.fields.quote_last_update
FROM
    "vtex"."schemaless"."b2b_suite_buyerorg_data_raw"
WHERE payload.name = 'b2b-suite-buyerorg-data'
and payload.kind = 'use-quote-ui-event'
order by ingestion_time desc
```

![image](https://github.com/vtex-apps/b2b-quotes/assets/1576737/4573946a-1d20-496a-8a00-dbeb47e2ccc4)


#### How does this PR make you feel?

![ ](https://media.giphy.com/media/JxPcknmMotohRhD6Pk/giphy.gif)
