### PR TITLE
Fix [customData] Extra validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed that if there is another custom application in the custom data, the "B2BQuotesLockingModal.tsx" component would break on its own.
+
 ## [1.6.0] - 2023-08-10
 
 + ### Added

--- a/react/components/B2BQuotesLockingModal.tsx
+++ b/react/components/B2BQuotesLockingModal.tsx
@@ -100,7 +100,12 @@ const B2BQuotesLockingModal = () => {
     const { orderForm } = orderFormData
     const { customData, items } = orderForm
 
-    if (!customData?.customApps || !customData?.customApps.some( (item: any) => item.id === 'b2b-quotes-graphql' )) {
+    if (
+      !customData?.customApps ||
+      !customData?.customApps.some(
+        (item: any) => item.id === 'b2b-quotes-graphql'
+      )
+    ) {
       return
     }
 

--- a/react/components/B2BQuotesLockingModal.tsx
+++ b/react/components/B2BQuotesLockingModal.tsx
@@ -100,7 +100,7 @@ const B2BQuotesLockingModal = () => {
     const { orderForm } = orderFormData
     const { customData, items } = orderForm
 
-    if (!customData?.customApps || customData?.customApps.findIndex( (item: any) => item.id === 'b2b-quotes-graphql' ) === -1) {
+    if (!customData?.customApps || !customData?.customApps.some( (item: any) => item.id === 'b2b-quotes-graphql' )) {
       return
     }
 

--- a/react/components/B2BQuotesLockingModal.tsx
+++ b/react/components/B2BQuotesLockingModal.tsx
@@ -100,7 +100,7 @@ const B2BQuotesLockingModal = () => {
     const { orderForm } = orderFormData
     const { customData, items } = orderForm
 
-    if (!customData?.customApps) {
+    if (!customData?.customApps || customData?.customApps.findIndex( (item: any) => item.id === 'b2b-quotes-graphql' ) === -1) {
       return
     }
 


### PR DESCRIPTION
#### What problem is this solving?
If there is another customApp in the customData, the "B2BQuotesLockingModal.tsx"component breaks on its own.

<!--- What is the motivation and context for this change? -->
#### Step by step to replicate the issue
1. Go to B2B and sign in as a member of an organization (if you need credentials to take the test, share your email to invite you as a member).
2. Add a SKU to the cart, go to Checkout and complete the necessary information until the Shipping step.
3. After going to Payment step, go back to Home and check how the Header will disappear.
<img width="1710" alt="Screenshot 2024-06-14 at 13 26 32" src="https://github.com/vtex-apps/b2b-quotes/assets/23274114/c061ddc5-6a18-4951-ac35-ed8836e8f85c">
<img width="1710" alt="Screenshot 2024-06-14 at 13 26 39" src="https://github.com/vtex-apps/b2b-quotes/assets/23274114/f224d254-fedf-4df5-bfe0-0186de064a95">


#### How to test it?
<!--- Don't forget to add a link to a Workspace where this branch is linked -->
[Workspace](https://devfeatures--lyonbakeryus.myvtex.com)