### PR TITLE
fix: validate input value and updates correctly adminSetup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Fixed the change of expiration date inserted in the input
 
 ## [1.6.4] - 2024-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 
-- Fixed the change of expiration date inserted in the input
+- Fix validation and submit on lifespan settings for quotes
 
 ## [1.6.4] - 2024-09-05
 

--- a/react/components/B2BQuotesLockingModal.tsx
+++ b/react/components/B2BQuotesLockingModal.tsx
@@ -159,7 +159,7 @@ const B2BQuotesLockingModal = () => {
           }
         >
           <div>
-            <h1>{formatMessage(messages.title)}</h1>
+            {/* <h1>{formatMessage(messages.title)}</h1> */}
             <p>{formatMessage(messages.message)}</p>
           </div>
         </Modal>

--- a/react/components/B2BQuotesLockingModal.tsx
+++ b/react/components/B2BQuotesLockingModal.tsx
@@ -159,7 +159,7 @@ const B2BQuotesLockingModal = () => {
           }
         >
           <div>
-            {/* <h1>{formatMessage(messages.title)}</h1> */}
+            <h1>{formatMessage(messages.title)}</h1>
             <p>{formatMessage(messages.message)}</p>
           </div>
         </Modal>

--- a/react/components/QuoteDetails/SaveButtons.tsx
+++ b/react/components/QuoteDetails/SaveButtons.tsx
@@ -30,7 +30,7 @@ const SaveButtons = ({
               updatingQuoteState
             }
           >
-            <FormattedMessage id="store/b2b-quotes.create.button.save-for-later" />
+            fdsdf
           </Button>
         </span>
         <span className="mr4">
@@ -44,11 +44,7 @@ const SaveButtons = ({
               updatingQuoteState
             }
           >
-            {isSalesRep ? (
-              <FormattedMessage id="store/b2b-quotes.quote-details.save" />
-            ) : (
-              <FormattedMessage id="store/b2b-quotes.create.button.request-quote" />
-            )}
+            asdfasdf
           </Button>
         </span>
       </Fragment>

--- a/react/components/QuoteDetails/SaveButtons.tsx
+++ b/react/components/QuoteDetails/SaveButtons.tsx
@@ -44,7 +44,7 @@ const SaveButtons = ({
               updatingQuoteState
             }
           >
-            asdfasdf
+            <FormattedMessage id="store/b2b-quotes.create.button.save-for-later" />
           </Button>
         </span>
       </Fragment>

--- a/react/components/QuoteDetails/SaveButtons.tsx
+++ b/react/components/QuoteDetails/SaveButtons.tsx
@@ -30,7 +30,7 @@ const SaveButtons = ({
               updatingQuoteState
             }
           >
-            fdsdf
+            <FormattedMessage id="store/b2b-quotes.create.button.save-for-later" />
           </Button>
         </span>
         <span className="mr4">


### PR DESCRIPTION
#### What problem is this solving?
Before, it not possible update the "expiration date" of quotes

#### How to test it?

1. Simulation Access the B2B Quotes settings page; 
2. Change the value of the "expiration period" field; 
3. Refresh the page; 

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://josmarjr--b2bstore005.myvtex.com/admin/b2b-quotes/settings)

#### Screenshots or example usage:
<img width="1433" alt="Screenshot 2024-09-12 at 13 51 45" src="https://github.com/user-attachments/assets/0d282db3-2398-422d-96aa-adda95a7e70d">

https://github.com/user-attachments/assets/42358669-ed01-4f23-9968-8138523454f6



#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
