### PR TITLE
fix: skip graphql query if parameter is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Skip graphl query if parameter is null
 
 ## [1.6.5] - 2024-09-26
 ### Fixed

--- a/react/B2BQuotesLink.tsx
+++ b/react/B2BQuotesLink.tsx
@@ -21,6 +21,7 @@ const B2BQuotesLink: FunctionComponent<Props> = ({ render }) => {
 
   const { data } = useQuery(CHECK_PERMISSIONS, {
     variables: { email: userEmail },
+    skip: !userEmail,
   })
 
   useEffect(() => {


### PR DESCRIPTION
#### What problem is this solving?

We were observing the error Variable "$email" of required type "String!" was not provided on the logs and this PR avoid calls that were causing the error.
Now the `getQuoteEnabledForUser` query is skipped if the userEmail parameter is empty (resulting in the same behaviour)


