### PR TITLE
Fix message request-quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix Request Quote message in Quotes Details
 
 ## [1.6.5] - 2024-09-26
 ### Fixed

--- a/react/components/QuoteDetails/SaveButtons.tsx
+++ b/react/components/QuoteDetails/SaveButtons.tsx
@@ -44,7 +44,7 @@ const SaveButtons = ({
               updatingQuoteState
             }
           >
-            <FormattedMessage id="store/b2b-quotes.create.button.save-for-later" />
+            <FormattedMessage id="store/b2b-quotes.create.button.request-quote" />
           </Button>
         </span>
       </Fragment>


### PR DESCRIPTION
#### What problem is this solving?

Wrong message key for the request-quote button

#### How to test it?

[fixmessage](https://fixmessage--b2bstore005.myvtex.com/b2b-quotes/create)

#### Screenshots or example usage:

Before:
![image](https://github.com/user-attachments/assets/f619087d-076a-4131-8282-11cce13414e3)

After:
![image](https://github.com/user-attachments/assets/c45a936a-99e2-4437-b658-31d3acede0cd)