### PR TITLE
[B2BTEAM-3259] Prevent NaNs in Quote Creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+### Fixed
+- Change subtotal and discount calculations to avoid NaNs
 
 ## [3.0.8] - 2026-03-10
 

--- a/react/components/QuoteDetails/QuoteDetails.tsx
+++ b/react/components/QuoteDetails/QuoteDetails.tsx
@@ -596,13 +596,13 @@ const QuoteDetails: FunctionComponent = () => {
 
   useEffect(() => {
     if (!quoteState.items.find((item) => item.error)) {
-      setUpdatingSubtotal(
-        quoteState.items.reduce(
-          (sum, item) =>
-            sum + item.sellingPrice * item.quantity * unitMultipliers[item.id],
-          0
-        )
+      const reducedSubtotal = quoteState.items.reduce(
+        (sum, item) =>
+          sum + item.sellingPrice * item.quantity * (unitMultipliers[item.id] ?? 1),
+        0
       )
+
+      setUpdatingSubtotal(reducedSubtotal)
     }
 
     const price = quoteState.items.reduce(
@@ -750,6 +750,7 @@ const QuoteDetails: FunctionComponent = () => {
     setQuoteState((prevState) => {
       return { ...prevState, items: itemsCopy }
     })
+
     setUpdatingSubtotal(subtotal)
   }, [isNewQuote, orderFormData, setEditable])
 
@@ -759,11 +760,9 @@ const QuoteDetails: FunctionComponent = () => {
   const computedSubtotal = useMemo(() => {
     const quoteItems = quoteState?.items || []
 
-    if (unitMultipliers.legth <= 0) return
-
     const detailedItems = quoteItems.map((item: any) => ({
       skuId: item.id,
-      effectivePrice: item.price * item.quantity * unitMultipliers[item.id],
+      effectivePrice: item.price * item.quantity * (unitMultipliers[item.id] ?? 1),
     }))
 
     return detailedItems.reduce(

--- a/react/components/QuoteDetails/QuoteTable.tsx
+++ b/react/components/QuoteDetails/QuoteTable.tsx
@@ -226,8 +226,6 @@ const QuoteTable = ({
     />
   )
 
-  console.log('>> Before computing', updatingSubtotal, computedSubtotal)
-
   const totalizers = [
     {
       label: formatMessage(quoteMessages.originalSubtotal),
@@ -270,8 +268,6 @@ const QuoteTable = ({
       },
     ]),
   ]
-
-  console.log('>>> Totalizers', totalizers)
 
   if (!isNewQuote || !checkedExternalSellers?.length) {
     return renderTable(quoteState.items, totalizers)

--- a/react/components/QuoteDetails/QuoteTable.tsx
+++ b/react/components/QuoteDetails/QuoteTable.tsx
@@ -226,6 +226,8 @@ const QuoteTable = ({
     />
   )
 
+  console.log('>> Before computing', updatingSubtotal, computedSubtotal)
+
   const totalizers = [
     {
       label: formatMessage(quoteMessages.originalSubtotal),
@@ -268,6 +270,8 @@ const QuoteTable = ({
       },
     ]),
   ]
+
+  console.log('>>> Totalizers', totalizers)
 
   if (!isNewQuote || !checkedExternalSellers?.length) {
     return renderTable(quoteState.items, totalizers)


### PR DESCRIPTION
#### What problem is this solving?

Quote Creation was without some guards in case there were no unit multipliers for the cart itens, this prevented the subtotal and discount calculations and resulted in NaNs being shown at the interface. 


#### How to test it?

1. Log in to [https://testvtex--nagarropartnerind 2. myvtex.com/](https://testvtex--nagarropartnerind2.myvtex.com/)
2. Add productId 84 (Horn – Valeo) to the cart.
3. Open the cart.
4. Click on Request a Quote.
5. Navigate to the Create Quote page.

[Workspace](https://testvtex--nagarropartnerind2.myvtex.com/)

#### Screenshots or example usage:

Before: 

<img width="2756" height="1178" alt="image" src="https://github.com/user-attachments/assets/dad96ba4-1966-45d4-976d-bd9574a2fd9b" />


After: 
<img width="1392" height="423" alt="image" src="https://github.com/user-attachments/assets/7b7287a9-8cb9-4691-97e0-674e33d57817" />


#### Related to / Depends on

[Slack Thread](https://vtex.slack.com/archives/C054PQH3GJF/p1772746929765389)

[Zendesk Issue](https://vtexhelp.zendesk.com/agent/tickets/1363253)
